### PR TITLE
Set up GoReleaser for releases and CI

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,6 +29,12 @@
       "matchDatasources": ["go"],
       "matchUpdateTypes": ["patch", "digest"],
       "automerge": true
+    },
+    {
+      "description": "Automerge Docker digest updates",
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["digest"],
+      "automerge": true
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,31 @@ jobs:
 
       - name: Test with coverage
         run: nix develop --command task coverage
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v16
+        with:
+          name: claytono
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build with GoReleaser (no publish)
+        run:
+          nix develop --command goreleaser release --snapshot --skip=publish
+          --clean

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -1,0 +1,89 @@
+name: Rebuild Latest Docker Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  rebuild-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get latest release tag
+        id: release
+        run: |
+          TAG=$(gh release view --json tagName -q '.tagName' 2>/dev/null || echo "")
+          if [ -z "$TAG" ]; then
+            echo "No release found, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download release binaries
+        if: steps.release.outputs.skip == 'false'
+        run: |
+          TAG="${{ steps.release.outputs.tag }}"
+          for arch in amd64 arm64; do
+            gh release download "$TAG" \
+              --pattern "go-unifi-mcp_linux_${arch}.tar.gz" \
+              --dir "dl-${arch}"
+            tar -xzf "dl-${arch}/go-unifi-mcp_linux_${arch}.tar.gz" \
+              -C "dl-${arch}"
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push images
+        if: steps.release.outputs.skip == 'false'
+        run: |
+          TAG="${{ steps.release.outputs.tag }}"
+          VERSION="${TAG#v}"
+
+          # Stage binaries in the layout expected by the Dockerfile
+          for arch in amd64 arm64; do
+            mkdir -p "linux/${arch}"
+            cp "dl-${arch}/go-unifi-mcp" "linux/${arch}/go-unifi-mcp"
+          done
+
+          for arch in amd64 arm64; do
+            docker buildx build \
+              --platform "linux/${arch}" \
+              --tag "ghcr.io/claytono/go-unifi-mcp:latest-${arch}" \
+              --label "org.opencontainers.image.title=go-unifi-mcp" \
+              --label "org.opencontainers.image.description=MCP server for UniFi Network Controller" \
+              --label "org.opencontainers.image.version=${VERSION}" \
+              --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+              --label "org.opencontainers.image.revision=${GITHUB_SHA}" \
+              --label "org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+              --push \
+              .
+          done
+
+          docker manifest create ghcr.io/claytono/go-unifi-mcp:latest \
+            ghcr.io/claytono/go-unifi-mcp:latest-amd64 \
+            ghcr.io/claytono/go-unifi-mcp:latest-arm64
+          docker manifest push ghcr.io/claytono/go-unifi-mcp:latest

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -1,0 +1,80 @@
+name: Edge
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  packages: write
+
+jobs:
+  edge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v16
+        with:
+          name: claytono
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser (snapshot)
+        run:
+          nix develop --command goreleaser release --clean --snapshot
+          --skip=docker
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push edge images
+        run: |
+          # Get the snapshot version from GoReleaser metadata
+          VERSION=$(jq -r '.version' dist/metadata.json)
+
+          # Stage binaries in the layout expected by the Dockerfile
+          for arch in amd64 arm64; do
+            mkdir -p "linux/${arch}"
+            src=$(ls -d dist/go-unifi-mcp_linux_${arch}*/go-unifi-mcp)
+            cp "$src" "linux/${arch}/go-unifi-mcp"
+          done
+
+          # Build and push image for each architecture
+          for arch in amd64 arm64; do
+            docker buildx build \
+              --platform "linux/${arch}" \
+              --tag "ghcr.io/claytono/go-unifi-mcp:edge-${arch}" \
+              --label "org.opencontainers.image.title=go-unifi-mcp" \
+              --label "org.opencontainers.image.description=MCP server for UniFi Network Controller" \
+              --label "org.opencontainers.image.version=${VERSION}" \
+              --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+              --label "org.opencontainers.image.revision=${GITHUB_SHA}" \
+              --label "org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+              --push \
+              .
+          done
+
+          # Create and push multi-arch manifest
+          docker manifest create ghcr.io/claytono/go-unifi-mcp:edge \
+            ghcr.io/claytono/go-unifi-mcp:edge-amd64 \
+            ghcr.io/claytono/go-unifi-mcp:edge-arm64
+          docker manifest push ghcr.io/claytono/go-unifi-mcp:edge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v16
+        with:
+          name: claytono
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        run: nix develop --command goreleaser release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ result
 *.swo
 *~
 
+# GoReleaser dist output
+dist/
+
 # Beads (JSONL committed only to beads-sync branch)
 .beads/issues.jsonl
 .beads/interactions.jsonl

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,8 @@ version: 2
 project_name: go-unifi-mcp
 
 builds:
-  - main: .
+  - id: go-unifi-mcp
+    main: ./cmd/go-unifi-mcp
     binary: go-unifi-mcp
     env:
       - CGO_ENABLED=0
@@ -13,6 +14,9 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/claytono/go-unifi-mcp/internal/server.Version={{.Version}}
 
 archives:
   - formats:
@@ -24,8 +28,24 @@ checksum:
 
 changelog:
   sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
-      - "^ci:"
+
+dockers_v2:
+  - ids:
+      - go-unifi-mcp
+    dockerfile: Dockerfile
+    images:
+      - ghcr.io/claytono/go-unifi-mcp
+    tags:
+      - "v{{ .Version }}"
+      - "{{ if not .IsSnapshot }}latest{{ else }}edge{{ end }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      "org.opencontainers.image.title": "{{ .ProjectName }}"
+      "org.opencontainers.image.description":
+        "MCP server for UniFi Network Controller"
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.source": "https://github.com/claytono/go-unifi-mcp"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+      "org.opencontainers.image.created": "{{ .Date }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
+
+RUN apk add --no-cache ca-certificates
+
+RUN addgroup -S unifi && adduser -S -G unifi unifi
+
+ARG TARGETPLATFORM
+COPY ${TARGETPLATFORM}/go-unifi-mcp /usr/local/bin/go-unifi-mcp
+
+USER unifi
+
+ENTRYPOINT ["/usr/local/bin/go-unifi-mcp"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,134 @@ assistants and other MCP clients to interact with your UniFi infrastructure.
 
 This project is under development. See the issue tracker for current progress.
 
+## Installation
+
+### Binary (GitHub Releases)
+
+Download pre-built binaries from the
+[Releases page](https://github.com/claytono/go-unifi-mcp/releases). Binaries are
+available for macOS and Linux (amd64/arm64).
+
+```bash
+# macOS (Apple Silicon)
+curl -L https://github.com/claytono/go-unifi-mcp/releases/latest/download/go-unifi-mcp_darwin_arm64.tar.gz | tar xz
+sudo mv go-unifi-mcp /usr/local/bin/
+
+# macOS (Intel)
+curl -L https://github.com/claytono/go-unifi-mcp/releases/latest/download/go-unifi-mcp_darwin_amd64.tar.gz | tar xz
+sudo mv go-unifi-mcp /usr/local/bin/
+
+# Linux (amd64)
+curl -L https://github.com/claytono/go-unifi-mcp/releases/latest/download/go-unifi-mcp_linux_amd64.tar.gz | tar xz
+sudo mv go-unifi-mcp /usr/local/bin/
+
+# Linux (arm64)
+curl -L https://github.com/claytono/go-unifi-mcp/releases/latest/download/go-unifi-mcp_linux_arm64.tar.gz | tar xz
+sudo mv go-unifi-mcp /usr/local/bin/
+```
+
+### Docker
+
+Multi-architecture images (amd64/arm64) are published to GitHub Container
+Registry.
+
+```bash
+# Latest (pinned to most recent release, rebuilt on base image updates)
+docker pull ghcr.io/claytono/go-unifi-mcp:latest
+
+# Edge (built from main on every merge, unstable)
+docker pull ghcr.io/claytono/go-unifi-mcp:edge
+```
+
+### Go Install
+
+```bash
+go install github.com/claytono/go-unifi-mcp/cmd/go-unifi-mcp@latest
+```
+
+## Configuration
+
+### UniFi Credentials
+
+The server requires access to a UniFi Network Controller. Two authentication
+methods are supported:
+
+1. **API Key** (preferred): Create an API key in your UniFi controller under
+   Settings > Control Plane > Integrations. Set `UNIFI_HOST` and
+   `UNIFI_API_KEY`.
+
+2. **Username/Password**: Use a local admin account. Set `UNIFI_HOST`,
+   `UNIFI_USERNAME`, and `UNIFI_PASSWORD`.
+
+### Claude Desktop
+
+Add to your `claude_desktop_config.json`:
+
+**Using the binary:**
+
+```json
+{
+  "mcpServers": {
+    "unifi": {
+      "command": "/usr/local/bin/go-unifi-mcp",
+      "env": {
+        "UNIFI_HOST": "https://your-controller:443",
+        "UNIFI_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+**Using Docker:**
+
+```json
+{
+  "mcpServers": {
+    "unifi": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "UNIFI_HOST",
+        "-e",
+        "UNIFI_API_KEY",
+        "ghcr.io/claytono/go-unifi-mcp:latest"
+      ],
+      "env": {
+        "UNIFI_HOST": "https://your-controller:443",
+        "UNIFI_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+```bash
+claude mcp add unifi -- go-unifi-mcp
+```
+
+Then set the required environment variables in your shell before running
+`claude`.
+
+### Environment Variables
+
+| Variable           | Required | Default   | Description                     |
+| ------------------ | -------- | --------- | ------------------------------- |
+| `UNIFI_HOST`       | Yes      | —         | UniFi controller URL            |
+| `UNIFI_API_KEY`    | \*       | —         | API key (preferred auth method) |
+| `UNIFI_USERNAME`   | \*       | —         | Username for password auth      |
+| `UNIFI_PASSWORD`   | \*       | —         | Password for password auth      |
+| `UNIFI_SITE`       | No       | `default` | UniFi site name                 |
+| `UNIFI_VERIFY_SSL` | No       | `true`    | Whether to verify SSL certs     |
+
+\* Either `UNIFI_API_KEY` or both `UNIFI_USERNAME` and `UNIFI_PASSWORD` must be
+set.
+
 ## Development
 
 ### Prerequisites


### PR DESCRIPTION
- Configure binary builds for linux/darwin on amd64/arm64
- Add multi-arch Docker images with non-root user
- Add release workflow triggered by version tags
- Add edge workflow to build `:edge` Docker images on every merge to main
- Add docker-latest workflow to rebuild `:latest` images when Dockerfile changes
- Alpine pinned by digest with Renovate auto-merge for updates
- Add installation and configuration docs to README

Docker tag scheme:
- `:vX.Y.Z` — immutable, from tagged releases
- `:latest` — most recent stable release, rebuilt on base image updates
- `:edge` — HEAD of main, unstable