### PR TITLE
Restore coverage thresholds and add prohibitions to CLAUDE.md

### DIFF
--- a/.testcoverage.yaml
+++ b/.testcoverage.yaml
@@ -1,8 +1,8 @@
 profile: coverage.out
 
 threshold:
-  total: 85
-  file: 85
+  total: 95
+  file: 90
 
 exclude:
   paths:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,44 @@
 
 MCP server for UniFi Network Controller written in Go.
 
+## ABSOLUTE PROHIBITIONS
+
+**The following actions are FORBIDDEN without explicit user permission. There
+are NO exceptions. Do not rationalize, justify, or work around these rules.**
+
+### 1. DO NOT CREATE OR MERGE PULL REQUESTS WITHOUT PERMISSION
+
+- Always ASK before creating a PR - never create one autonomously
+- NEVER merge PRs - merging is the user's responsibility
+- Even if tests pass, even if it looks ready, even if the user seems busy - ASK
+  FIRST
+
+### 2. DO NOT BYPASS PRE-COMMIT HOOKS
+
+- Never use `--no-verify` on any git command
+- Never disable or skip hooks "temporarily"
+- If hooks fail, FIX THE ISSUE - do not bypass
+- Hook failures exist to catch problems - respect them
+
+### 3. DO NOT CHANGE CODE COVERAGE THRESHOLDS
+
+- The coverage thresholds in `.testcoverage.yaml` are SACRED
+- Never lower `total` or `file` thresholds for any reason
+- If coverage is failing, write more tests - do not lower the bar
+- This includes "temporary" changes - there is no such thing
+
+### 4. DO NOT RUSH
+
+- Rushing leads to sloppy work that wastes MORE time later
+- Take the time to do things correctly the first time
+- If something seems hard, that's a sign to slow down, not speed up
+- Quality gates exist for a reason - do not circumvent them to "save time"
+
+**If you find yourself tempted to violate any of these rules, STOP and ask the
+user for guidance. The answer is almost certainly "no, do it correctly."**
+
+---
+
 ## Development
 
 This project uses Nix for development environment management. Run `nix develop`
@@ -28,7 +66,7 @@ task generate    # Run go generate
 - Use `goimports` for import organization (local prefix:
   `github.com/claytono/go-unifi-mcp`)
 - Follow standard Go conventions
-- Maintain 85% total test coverage, 85% per file
+- Maintain 95% total test coverage, 90% per file (DO NOT CHANGE THESE VALUES)
 
 ### Type Generation
 


### PR DESCRIPTION
Restore the original coverage thresholds (95% total, 90% per file) that
were incorrectly lowered in Phase 3.

Add explicit prohibitions section to CLAUDE.md forbidding:
- Merging PRs without permission
- Bypassing pre-commit hooks
- Changing coverage thresholds
- Rushing through work

These rules exist to maintain code quality and prevent mistakes that
waste time later.
