### PR TITLE
Fix go-test-coverage build with Go 1.25

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,11 @@
 
         vendorHash = "sha256-iJ3VFnzPYd0ovyK/QdCDolh5p8fe/aXulnHxAia5UuE=";
 
-        # Skip tests - upstream has integration tests that require GitHub credentials
-        # https://github.com/vladopajic/go-test-coverage/issues/243
+        # Skip tests entirely - upstream has two issues:
+        # 1. Integration tests that require GitHub credentials (#243)
+        # 2. Nil pointer bug in Test_Github_Error with Go 1.25 (#266)
         doCheck = false;
+        checkPhase = "";
 
         meta = {
           description = "Tool to report issues when test coverage falls below threshold";


### PR DESCRIPTION
## Summary

- Fix CI failures caused by go-test-coverage nil pointer bug with Go 1.25
- Add `checkPhase = ""` to ensure tests are completely disabled during Nix build

## Context

The go-test-coverage v2.18.3 package has a nil pointer dereference in `Test_Github_Error` that manifests with Go 1.25's stricter nil pointer checking (which fixed a spec violation). This was causing both lint and test CI jobs to fail during `nix develop`.

Filed upstream: https://github.com/vladopajic/go-test-coverage/issues/266

## Test plan

- [x] Verified `nix develop` works locally with the fix
- [ ] CI passes