### PR TITLE
Add Nix packaging and Homebrew tap publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,4 @@ jobs:
         run: nix develop --command goreleaser release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,27 @@ archives:
 checksum:
   name_template: checksums.txt
 
+brews:
+  - name: go-unifi-mcp
+    description: MCP server for UniFi Network Controller
+    homepage: https://github.com/claytono/go-unifi-mcp
+    license: MPL-2.0
+    url_template:
+      https://github.com/claytono/go-unifi-mcp/releases/download/{{ .Tag }}/{{
+      .ArtifactName }}
+    directory: Formula
+    repository:
+      owner: claytono
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    commit_author:
+      name: Clayton O'Neill
+      email: claytono@users.noreply.github.com
+    test: |
+      system "#{bin}/go-unifi-mcp", "--help"
+    install: |
+      bin.install "go-unifi-mcp"
+
 changelog:
   sort: asc
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ curl -L https://github.com/claytono/go-unifi-mcp/releases/latest/download/go-uni
 sudo mv go-unifi-mcp /usr/local/bin/
 ```
 
+### Nix
+
+```bash
+# Run without installing
+nix run github:claytono/go-unifi-mcp
+
+# Install to your profile
+nix profile install github:claytono/go-unifi-mcp
+```
+
 ### Docker
 
 Multi-architecture images (amd64/arm64) are published to GitHub Container


### PR DESCRIPTION
## Summary
- add flake package/app outputs for Nix installs
- publish Homebrew formula to claytono/homebrew-tap via GoReleaser
- document Nix install commands in README