### PR TITLE
Speed up NewClient tests

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,8 @@ import (
 // Version is set at build time.
 var Version = "dev"
 
+var newUnifiClient = unifi.NewClient
+
 const ServerName = "go-unifi-mcp"
 
 // Mode determines how tools are registered with the MCP server.
@@ -82,7 +84,7 @@ func NewClient(cfg *config.Config) (unifi.Client, error) {
 		clientCfg.Password = cfg.Password
 	}
 
-	return unifi.NewClient(clientCfg)
+	return newUnifiClient(clientCfg)
 }
 
 // Serve starts the MCP server on stdio.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/claytono/go-unifi-mcp/internal/config"
 	servermocks "github.com/claytono/go-unifi-mcp/internal/server/mocks"
+	"github.com/filipowm/go-unifi/unifi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew_RequiresClient(t *testing.T) {
@@ -33,10 +35,25 @@ func TestNewClient_APIKey(t *testing.T) {
 		VerifySSL: false,
 	}
 
-	// This will fail to connect but validates config mapping
-	_, err := NewClient(cfg)
-	// Error expected since no server is running
-	assert.Error(t, err)
+	var captured *unifi.ClientConfig
+	prevFactory := newUnifiClient
+	newUnifiClient = func(clientCfg *unifi.ClientConfig) (unifi.Client, error) {
+		captured = clientCfg
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		newUnifiClient = prevFactory
+	})
+
+	client, err := NewClient(cfg)
+	assert.NoError(t, err)
+	assert.Nil(t, client)
+	require.NotNil(t, captured)
+	assert.Equal(t, cfg.Host, captured.URL)
+	assert.Equal(t, cfg.VerifySSL, captured.VerifySSL)
+	assert.Equal(t, cfg.APIKey, captured.APIKey)
+	assert.Empty(t, captured.User)
+	assert.Empty(t, captured.Password)
 }
 
 func TestNewClient_UserPass(t *testing.T) {
@@ -48,10 +65,25 @@ func TestNewClient_UserPass(t *testing.T) {
 		VerifySSL: false,
 	}
 
-	// This will fail to connect but validates config mapping
-	_, err := NewClient(cfg)
-	// Error expected since no server is running
-	assert.Error(t, err)
+	var captured *unifi.ClientConfig
+	prevFactory := newUnifiClient
+	newUnifiClient = func(clientCfg *unifi.ClientConfig) (unifi.Client, error) {
+		captured = clientCfg
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		newUnifiClient = prevFactory
+	})
+
+	client, err := NewClient(cfg)
+	assert.NoError(t, err)
+	assert.Nil(t, client)
+	require.NotNil(t, captured)
+	assert.Equal(t, cfg.Host, captured.URL)
+	assert.Equal(t, cfg.VerifySSL, captured.VerifySSL)
+	assert.Empty(t, captured.APIKey)
+	assert.Equal(t, cfg.Username, captured.User)
+	assert.Equal(t, cfg.Password, captured.Password)
 }
 
 func TestMode_DefaultsToLazy(t *testing.T) {


### PR DESCRIPTION
## Summary
- inject UniFi client constructor to avoid network calls in tests
- assert NewClient config mapping without timeouts

Tests: go test ./internal/server -run TestNewClient -count=1