### PR TITLE
Simplify latest image publishing

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push images
+      - name: Build and push image
         if: steps.release.outputs.skip == 'false'
         run: |
           TAG="${{ steps.release.outputs.tag }}"
@@ -69,21 +69,14 @@ jobs:
             cp "dl-${arch}/go-unifi-mcp" "linux/${arch}/go-unifi-mcp"
           done
 
-          for arch in amd64 arm64; do
-            docker buildx build \
-              --platform "linux/${arch}" \
-              --tag "ghcr.io/claytono/go-unifi-mcp:latest-${arch}" \
-              --label "org.opencontainers.image.title=go-unifi-mcp" \
-              --label "org.opencontainers.image.description=MCP server for UniFi Network Controller" \
-              --label "org.opencontainers.image.version=${VERSION}" \
-              --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
-              --label "org.opencontainers.image.revision=${GITHUB_SHA}" \
-              --label "org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-              --push \
-              .
-          done
-
-          docker manifest create ghcr.io/claytono/go-unifi-mcp:latest \
-            ghcr.io/claytono/go-unifi-mcp:latest-amd64 \
-            ghcr.io/claytono/go-unifi-mcp:latest-arm64
-          docker manifest push ghcr.io/claytono/go-unifi-mcp:latest
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag "ghcr.io/claytono/go-unifi-mcp:latest" \
+            --label "org.opencontainers.image.title=go-unifi-mcp" \
+            --label "org.opencontainers.image.description=MCP server for UniFi Network Controller" \
+            --label "org.opencontainers.image.version=${VERSION}" \
+            --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+            --label "org.opencontainers.image.revision=${GITHUB_SHA}" \
+            --label "org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            --push \
+            .


### PR DESCRIPTION
## Summary
- build and push a single multi-arch latest image
- remove per-arch tags and manual manifest creation

Tests: not run (workflow change only)