### PR TITLE
Add changelog-driven release notes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,6 +37,16 @@
       ],
       "depNameTemplate": "philschmid/mcp-cli",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^flake\\.nix$"],
+      "matchStrings": [
+        "pname\\s*=\\s*\"python-kacl\";[\\s\\S]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";"
+      ],
+      "depNameTemplate": "schmieder.matthias/python-kacl",
+      "datasourceTemplate": "gitlab-tags",
+      "registryUrlTemplate": "https://gitlab.com"
     }
   ],
   "gitIgnoredAuthors": ["github-actions[bot]@users.noreply.github.com"],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract release notes
+        run: |
+          mkdir -p .tmp
+          VERSION="${GITHUB_REF_NAME#v}"
+          nix develop --command kacl-cli get "$VERSION" > .tmp/release-notes.md
+
       - name: Run GoReleaser
-        run: nix develop --command goreleaser release --clean
+        run: |
+          nix develop --command goreleaser release --clean --release-notes .tmp/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,7 +53,7 @@ brews:
       bin.install "go-unifi-mcp"
 
 changelog:
-  sort: asc
+  disable: true
 
 release:
   footer: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,11 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  - repo: https://gitlab.com/schmieder.matthias/python-kacl
+    rev: v0.6.8
+    hooks:
+      - id: kacl-verify
+
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-01-29
+
+### Added
+
+- MCP server for UniFi Network Controller with 240+ auto-generated tools
+- Lazy mode with 3 meta-tools (tool_index, execute, batch) for LLM-friendly
+  operation
+- Eager mode exposing all tools directly for MCP clients that handle large tool
+  sets
+- Docker multi-arch images (linux/amd64, linux/arm64) published to ghcr.io
+- Homebrew tap install via `brew install claytono/tap/go-unifi-mcp`
+- Nix flake support for reproducible builds and installation
+- Pre-built binaries for linux and macOS (amd64 and arm64)
+- Configurable site selection and authentication via environment variables
+
+[0.1.0]: https://github.com/claytono/go-unifi-mcp/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,29 @@ edit generated type files. See Phase 2 documentation for sync process.
 - Mock definitions live in `internal/server/mocks`
 - Do not edit generated mocks manually
 
+### Releasing
+
+This project uses a `CHANGELOG.md` in
+[Keep a Changelog](https://keepachangelog.com/) format. The release workflow
+uses `kacl-cli` to extract the version's notes and passes them to goreleaser.
+
+Release process:
+
+1. Update `CHANGELOG.md` with a new version section
+2. Run quality gates: `task lint && task coverage && task build`
+3. Commit and push to main
+4. Tag: `git tag -a vX.Y.Z -m "vX.Y.Z: brief summary"`
+5. Push tag: `git push origin vX.Y.Z`
+6. Wait for release workflow: `gh run watch --exit-status`
+7. Verify: `gh release view vX.Y.Z`
+
+Changelog entries:
+
+- Use categories: Added, Changed, Deprecated, Removed, Fixed, Security
+- Write for humans — concise, one line per change
+- `kacl-cli verify` runs as a pre-commit hook to validate format
+- Goreleaser auto-appends the UniFi Controller version footer
+
 ## Issue Tracking
 
 This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,38 @@
         };
       };
 
+      # python-kacl for changelog validation and extraction
+      mkPythonKacl = pkgs: pkgs.python3Packages.buildPythonApplication rec {
+        pname = "python-kacl";
+        version = "0.6.8";
+        pyproject = true;
+
+        src = pkgs.fetchFromGitLab {
+          owner = "schmieder.matthias";
+          repo = "python-kacl";
+          rev = "v${version}";
+          name = "python-kacl-source";
+          hash = "sha256-BJ4SlpiRL5InRJKc2gufCnYXjGlaQebXSHDeBegKY/I=";
+        };
+
+        build-system = with pkgs.python3Packages; [ setuptools ];
+
+        dependencies = with pkgs.python3Packages; [
+          click
+          semver
+          gitpython
+          pyyaml
+          jira
+        ];
+
+        doCheck = false;
+
+        meta = {
+          description = "CLI tool to manage changelogs in Keep a Changelog format";
+          homepage = "https://gitlab.com/schmieder.matthias/python-kacl";
+        };
+      };
+
       # mcp-cli for invoking MCP servers from CLI
       # Returns null on unsupported platforms (aarch64-linux has no binary)
       mkMcpCli = pkgs: let
@@ -129,6 +161,7 @@
             goreleaser
             go-mockery
             (mkGoTestCoverage pkgs)
+            (mkPythonKacl pkgs)
           ] ++ lib.optional (mkMcpCli pkgs != null) (mkMcpCli pkgs);
         };
       });

--- a/scripts/renovate-update-flake-hashes
+++ b/scripts/renovate-update-flake-hashes
@@ -256,6 +256,56 @@ def update_mcp_cli():
         write_flake_content(content)
 
 
+def update_python_kacl():
+    """Update source hash for python-kacl."""
+    content = get_flake_content()
+
+    # 1. Get version
+    version_pattern = r'pname\s*=\s*"python-kacl";[\s\S]*?version\s*=\s*"([^"]+)";'
+    match = re.search(version_pattern, content)
+    if not match:
+        print("Could not find python-kacl version")
+        return
+    version = match.group(1)
+
+    # 2. Set dummy hash and build to get real hash
+    print(f"Updating python-kacl v{version} source hash...")
+    dummy_hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    content = update_value(
+        content, "hash", dummy_hash, context_pattern=r'pname\s*=\s*"python-kacl";'
+    )
+    write_flake_content(content)
+
+    system_proc = run_nix(
+        ["eval", "--impure", "--raw", "--expr", "builtins.currentSystem"], check=False
+    )
+    system = (
+        system_proc.stdout.strip() if system_proc.returncode == 0 else "x86_64-linux"
+    )
+
+    print(f"Building devShell for {system} to get hash...")
+    proc = run_nix(["build", f".#devShells.{system}.default", "--no-link"], check=False)
+
+    new_hash = extract_hash_for_derivation(proc.stderr, r"python-kacl-source")
+    if new_hash:
+        print(f"Found new hash: {new_hash}")
+        content = get_flake_content()
+        content = update_value(
+            content,
+            "hash",
+            new_hash,
+            context_pattern=r'pname\s*=\s*"python-kacl";',
+        )
+        write_flake_content(content)
+    else:
+        print(
+            "Failed to extract new hash for python-kacl. Build output:",
+            file=sys.stderr,
+        )
+        print(proc.stderr, file=sys.stderr)
+        sys.exit(1)
+
+
 def main():
     if not FLAKE_FILE.exists():
         print(f"Error: {FLAKE_FILE} not found", file=sys.stderr)
@@ -264,6 +314,7 @@ def main():
     update_main_vendor_hash()
     update_mcp_cli()
     update_go_test_coverage()
+    update_python_kacl()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add CHANGELOG.md in Keep a Changelog format
- Disable goreleaser auto-changelog, use kacl-cli to extract
  version-specific notes and pass to goreleaser via --release-notes
- Add kacl-verify pre-commit hook for changelog format validation
- Package python-kacl in flake.nix with Renovate auto-update support
- Document release process in CLAUDE.md
