### PR TITLE
Fix nix-prefetch-github missing deps in CI

### DIFF
--- a/scripts/renovate-update-flake-hashes
+++ b/scripts/renovate-update-flake-hashes
@@ -146,6 +146,8 @@ def update_go_test_coverage():
         [
             "shell",
             "nixpkgs#nix-prefetch-github",
+            "nixpkgs#nix",
+            "nixpkgs#nix-prefetch-git",
             "--command",
             "nix-prefetch-github",
             "vladopajic",


### PR DESCRIPTION
nix-prefetch-github requires nix-build, nix-prefetch-url, and
nix-prefetch-git in PATH. Locally these exist in the system Nix
profile, but on CI runners inside `nix shell` they aren't available.

Add nixpkgs#nix and nixpkgs#nix-prefetch-git to the nix shell
invocation so all required tools are present.
