### PR TITLE
Fix Renovate Go version tracking in flake.nix

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,10 +15,12 @@
     {
       "customType": "regex",
       "fileMatch": ["^flake\\.nix$"],
-      "matchStrings": ["go_(?<currentValue>[0-9_]+)"],
+      "matchStrings": ["go_(?<major>\\d+)_(?<minor>\\d+)"],
+      "currentValueTemplate": "{{{major}}}.{{{minor}}}",
       "depNameTemplate": "golang",
       "datasourceTemplate": "golang-version",
-      "versioningTemplate": "loose"
+      "versioningTemplate": "go-mod-directive",
+      "autoReplaceStringTemplate": "go_{{{newMajor}}}_{{{newMinor}}}"
     },
     {
       "customType": "regex",
@@ -67,6 +69,12 @@
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["digest"],
       "automerge": true
+    },
+    {
+      "description": "Bump Go version in flake.nix on new minor releases",
+      "matchDatasources": ["golang-version"],
+      "matchDepNames": ["golang"],
+      "rangeStrategy": "bump"
     }
   ]
 }


### PR DESCRIPTION
The regex manager was extracting "1_25" from go_1_25 and comparing it
against the golang-version datasource which returns "1.25.6", causing a
format mismatch and "Error updating branch" failures.

- Capture major/minor as named groups, construct "1.25" via
  currentValueTemplate for proper version comparison
- Use go-mod-directive versioning so patch bumps (1.25.x) are ignored
  since nixpkgs manages patch versions internally
- Use autoReplaceStringTemplate to produce valid nix attribute names
  (go_1_26) when a new minor version is available
- Add rangeStrategy bump rule scoped to this dep so minor version
  updates are proposed
