### PR TITLE
Publish to MCP Registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,32 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+  publish-mcp-registry:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v16
+        with:
+          name: claytono
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Set version in server.json
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i "s/\"version\": \"0.0.0-dev\"/\"version\": \"${VERSION}\"/g" server.json
+          grep -q "\"version\": \"${VERSION}\"" server.json || { echo "Failed to set version in server.json"; exit 1; }
+
+      - name: Publish to MCP Registry
+        run: |
+          nix develop --command bash -c 'mcp-publisher login github-oidc && mcp-publisher publish'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,3 +76,4 @@ dockers_v2:
       "org.opencontainers.image.source": "https://github.com/claytono/go-unifi-mcp"
       "org.opencontainers.image.revision": "{{ .FullCommit }}"
       "org.opencontainers.image.created": "{{ .Date }}"
+      "io.modelcontextprotocol.server.name": "io.github.claytono/go-unifi-mcp"

--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,53 @@
         };
       };
 
+      # mcp-publisher for publishing to MCP Registry
+      mkMcpPublisher = pkgs: let
+        version = "1.4.0";
+        sources = {
+          "aarch64-darwin" = {
+            url = "https://github.com/modelcontextprotocol/registry/releases/download/v${version}/mcp-publisher_darwin_arm64.tar.gz";
+            hash = "sha256-nt27uV79VLlQP2wGaPQ7qz8EyFaUbTxxZPba6tIyQC8=";
+          };
+          "x86_64-darwin" = {
+            url = "https://github.com/modelcontextprotocol/registry/releases/download/v${version}/mcp-publisher_darwin_amd64.tar.gz";
+            hash = "sha256-61+Jt2/EWpcHD6SB6wOXdYSnjj3/J4FALUNILxFOTWo=";
+          };
+          "x86_64-linux" = {
+            url = "https://github.com/modelcontextprotocol/registry/releases/download/v${version}/mcp-publisher_linux_amd64.tar.gz";
+            hash = "sha256-xLQCtDqFFmw/hAZByhyebeW/oc9TPCJXbWY8y9oHEbs=";
+          };
+          "aarch64-linux" = {
+            url = "https://github.com/modelcontextprotocol/registry/releases/download/v${version}/mcp-publisher_linux_arm64.tar.gz";
+            hash = "sha256-ul1Ib4ayzvSOpQboMU2QGlFp3NVqXW6drxjUEkQxYjU=";
+          };
+        };
+        src = sources.${pkgs.stdenv.hostPlatform.system} or null;
+      in if src == null then null else pkgs.stdenv.mkDerivation {
+        pname = "mcp-publisher";
+        inherit version;
+
+        src = pkgs.fetchurl {
+          inherit (src) url hash;
+        };
+
+        sourceRoot = ".";
+        unpackPhase = ''
+          tar xzf $src
+        '';
+
+        installPhase = ''
+          mkdir -p $out/bin
+          cp mcp-publisher $out/bin/
+          chmod +x $out/bin/mcp-publisher
+        '';
+
+        meta = {
+          description = "CLI tool for publishing servers to the MCP Registry";
+          homepage = "https://github.com/modelcontextprotocol/registry";
+        };
+      };
+
       # mcp-cli for invoking MCP servers from CLI
       # Returns null on unsupported platforms (aarch64-linux has no binary)
       mkMcpCli = pkgs: let
@@ -163,7 +210,8 @@
             go-mockery
             (mkGoTestCoverage pkgs)
             (mkPythonKacl pkgs)
-          ] ++ lib.optional (mkMcpCli pkgs != null) (mkMcpCli pkgs);
+          ] ++ lib.optional (mkMcpCli pkgs != null) (mkMcpCli pkgs)
+            ++ lib.optional (mkMcpPublisher pkgs != null) (mkMcpPublisher pkgs);
         };
       });
     };

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.claytono/go-unifi-mcp",
+  "description": "Manage UniFi sites, devices, clients, networks, port forwarding, DNS, and firewall",
+  "version": "0.0.0-dev",
+  "repository": {
+    "url": "https://github.com/claytono/go-unifi-mcp",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registry_type": "oci",
+      "registry_base_url": "https://ghcr.io",
+      "identifier": "claytono/go-unifi-mcp",
+      "version": "0.0.0-dev",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Add server.json with MCP registry metadata
- Add publish-mcp-registry job to release workflow (runs after
  GoReleaser, uses GitHub OIDC for auth)
- Add io.modelcontextprotocol.server.name Docker label for OCI
  verification
