### PR TITLE
Fix OCI package identifier in server.json

### DIFF
--- a/server.json
+++ b/server.json
@@ -10,8 +10,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "registryBaseUrl": "https://ghcr.io",
-      "identifier": "claytono/go-unifi-mcp",
+      "identifier": "ghcr.io/claytono/go-unifi-mcp",
       "version": "0.0.0-dev",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Use canonical reference (ghcr.io/claytono/go-unifi-mcp) in identifier
field instead of separate registryBaseUrl, as required by the MCP
Registry for OCI packages.
