### PR TITLE
Fix OCI package format in server.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Set version in server.json
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          sed -i "s/\"version\": \"0.0.0-dev\"/\"version\": \"${VERSION}\"/g" server.json
+          sed -i "s/0\.0\.0-dev/${VERSION}/g" server.json
           grep -q "\"version\": \"${VERSION}\"" server.json || { echo "Failed to set version in server.json"; exit 1; }
 
       - name: Publish to MCP Registry

--- a/server.json
+++ b/server.json
@@ -10,8 +10,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/claytono/go-unifi-mcp",
-      "version": "0.0.0-dev",
+      "identifier": "ghcr.io/claytono/go-unifi-mcp:0.0.0-dev",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
OCI packages must not have a version field; the version is encoded as a
tag in the identifier (ghcr.io/claytono/go-unifi-mcp:VERSION). Update
sed to replace all 0.0.0-dev placeholders.
