### PR TITLE
Fix OCI image tag in MCP registry publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,10 @@ jobs:
       - name: Set version in server.json
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          sed -i "s/0\.0\.0-dev/${VERSION}/g" server.json
+          TAG="${GITHUB_REF_NAME}"
+          jq --arg v "$VERSION" --arg t "$TAG" \
+            '.version = $v | .packages[0].identifier = "ghcr.io/claytono/go-unifi-mcp:" + $t' \
+            server.json > server.json.tmp && mv server.json.tmp server.json
           grep -q "\"version\": \"${VERSION}\"" server.json || { echo "Failed to set version in server.json"; exit 1; }
 
       - name: Publish to MCP Registry


### PR DESCRIPTION
GoReleaser tags images with v prefix (v0.1.1), so the identifier must
use the full tag name. Switch from sed to jq for precise field updates.
