### PR TITLE
Pin GitHub Actions to SHA digests via Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigestsToSemver"],
   "rebaseWhen": "behind-base-branch",
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,


### PR DESCRIPTION
Add helpers:pinGitHubActionDigestsToSemver preset so Renovate
automatically pins all action references to commit SHAs and keeps
them updated.
