### PR TITLE
Add Renovate eval workflow

### DIFF
--- a/.claude/renovate-eval.md
+++ b/.claude/renovate-eval.md
@@ -1,0 +1,60 @@
+# Renovate Eval Context
+
+## Role of This File
+
+This file provides repository context, discovery hints, validation commands, and
+action-menu behavior for Renovate PR evaluation. It does not redefine the shared
+`renovate:safe`, `renovate:caution`, `renovate:breaking`, or `renovate:risk`
+label semantics.
+
+## Repo Layout
+
+- Go application entry points: `cmd/`
+- Internal packages: `internal/`
+- Public Go packages: `pkg/`
+- Generated UniFi API types and tool metadata: inspect generated-file headers
+  before recommending manual edits
+- Nix development environment and packaged tools: `flake.nix` and `flake.lock`
+- Go module metadata: `go.mod` and `go.sum`
+- Release automation: `.goreleaser.yml`, `RELEASE.md`, and release workflows
+- Renovate configuration: `.github/renovate.json`
+
+## Normal Validation Actions
+
+- `nix develop --command task lint` runs repository linters. The CI lint job
+  skips `go-test-coverage` there because coverage is checked by the test job.
+- `nix develop --command task coverage` runs tests with coverage thresholds.
+- `nix develop --command task build` builds the binary.
+- `nix develop --command task generate` regenerates generated code when a
+  dependency update changes generated UniFi API surfaces.
+- Docker/release impact is validated by the CI Docker job with GoReleaser
+  snapshot builds.
+- Renovate PRs may trigger `.github/workflows/renovate-flake-hash-fix.yaml`,
+  which fixes Nix hash mismatches in `flake.nix`.
+
+## Config Discovery
+
+- Go dependency updates are usually in `go.mod` and `go.sum`.
+- Updates to the pinned UniFi controller surface may involve
+  `.go-unifi-version`, generated files, and release notes from
+  `filipowm/go-unifi`.
+- Flake-managed tool updates usually touch `flake.nix` and may require hash
+  refreshes.
+- Docker and GitHub Actions updates are managed by workflow files and
+  `.goreleaser.yml`.
+- Coverage settings are controlled by `.testcoverage.yaml`; do not recommend
+  lowering thresholds.
+
+## Notes
+
+- The repository enforces 95% total coverage and 90% per-file coverage.
+- Generated types and generated mocks should not be edited manually.
+- Releases publish binaries, Docker images, Homebrew tap updates, and MCP
+  registry metadata; dependency changes can affect more than the Go test suite.
+
+## Actions Menu
+
+Include the default shared actions menu. Add a "Regenerate and test" action when
+the update changes `filipowm/go-unifi`, `.go-unifi-version`, generated files, or
+generation tooling, because those PRs may need `task generate` followed by the
+normal lint, coverage, and build checks.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -54,6 +54,13 @@
   "gitIgnoredAuthors": ["github-actions[bot]@users.noreply.github.com"],
   "packageRules": [
     {
+      "description": "Do not pin the reusable Renovate evaluation workflow; it intentionally tracks main",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["claytono/github-actions"],
+      "matchUpdateTypes": ["pinDigest"],
+      "enabled": false
+    },
+    {
       "description": "Automerge pre-commit hook updates",
       "matchManagers": ["pre-commit"],
       "automerge": true

--- a/.github/workflows/renovate-eval.yaml
+++ b/.github/workflows/renovate-eval.yaml
@@ -1,0 +1,54 @@
+---
+name: Renovate PR Evaluation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to evaluate, or 'all' for all unevaluated
+        required: true
+        type: string
+      dry_run:
+        description: Evaluate but do not post or label
+        required: false
+        type: boolean
+        default: false
+      codex_runner_label:
+        description: Runner label for Codex evaluation
+        required: false
+        type: string
+        default: codex
+      codex_reasoning_effort:
+        description: Codex reasoning effort
+        required: false
+        type: string
+        default: xhigh
+      codex_agent_timeout:
+        description: Codex agent subprocess timeout in seconds; 0 disables it
+        required: false
+        type: string
+        default: "0"
+
+jobs:
+  renovate-eval:
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      issues: write
+      checks: read
+      statuses: read
+    # Intentionally tracks main so evaluator workflow changes take effect immediately.
+    # Renovate pinDigest updates for this reusable workflow are disabled in .github/renovate.json.
+    uses: claytono/github-actions/.github/workflows/claytono-renovate-eval-codex.yaml@main # zizmor: ignore[unpinned-uses]
+    with:
+      pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
+      trigger: ${{ github.event_name == 'pull_request' && 'auto' || 'manual' }}
+      dry_run: ${{ inputs.dry_run || false }}
+      codex_runner_label: ${{ inputs.codex_runner_label || 'codex' }}
+      codex_reasoning_effort: ${{ inputs.codex_reasoning_effort || 'xhigh' }}
+      codex_agent_timeout: ${{ inputs.codex_agent_timeout || '0' }}
+    secrets:
+      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}


### PR DESCRIPTION
Add the shared Codex Renovate evaluation caller workflow and go-unifi-mcp-specific evaluation context.
