### PR TITLE
Prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-07-15
+
+### Added
+
+- Add 10 tools from go-unifi v1.11.2, expanding eager mode from 242 to 252
+  tools. Content filtering can now be listed, created, updated, and deleted with
+  `list_content_filtering`, `create_content_filtering`,
+  `update_content_filtering`, and `delete_content_filtering`, including
+  allow/block lists, category selection, safe-search providers, client and
+  network targeting, and schedules. New get/update tool pairs also expose mDNS,
+  roaming assistant, and traffic-flow settings (#126)
+
+### Changed
+
+- Update generated UniFi schemas to go-unifi v1.11.2, adding current controller
+  fields such as network member groups, mDNS proxy configuration, radio presets,
+  high-priority devices, and expanded WAN interface support (#126)
+- Update the MCP runtime, Go and Nix toolchains, container base image,
+  development dependencies, and GitHub Actions used for building and publishing
+  releases (#67–#123)
+- Improve Renovate evaluation and fixed-output Nix hash repair so dependency
+  updates can be reviewed and regenerated more reliably (#122, #124)
+
 ## [0.2.0] - 2026-02-03
 
 ### Added
@@ -52,6 +75,7 @@ and this project adheres to
 - Pre-built binaries for linux and macOS (amd64 and arm64)
 - Configurable site selection and authentication via environment variables
 
+[0.3.0]: https://github.com/claytono/go-unifi-mcp/releases/tag/v0.3.0
 [0.2.0]: https://github.com/claytono/go-unifi-mcp/releases/tag/v0.2.0
 [0.1.1]: https://github.com/claytono/go-unifi-mcp/releases/tag/v0.1.1
 [0.1.0]: https://github.com/claytono/go-unifi-mcp/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ established by
 | Mode    | Tools | Context Size | Description                                     |
 | ------- | ----- | ------------ | ----------------------------------------------- |
 | `lazy`  | 3     | ~200 tokens  | Meta-tools only (default, recommended for LLMs) |
-| `eager` | 242   | ~55K tokens  | All tools registered directly                   |
+| `eager` | 252   | ~55K tokens  | All tools registered directly                   |
 
-**Lazy mode** (default) registers only 3 meta-tools that provide access to 242
+**Lazy mode** (default) registers only 3 meta-tools that provide access to 252
 UniFi operations (generated from the controller API):
 
 - `tool_index` - Search/filter the tool catalog by category or resource
@@ -211,7 +211,7 @@ This dramatically reduces context window usage while preserving full
 functionality. The LLM first queries the index to find relevant tools, then
 executes them via the dispatcher.
 
-**Eager mode** registers all 242 tools directly, which may be useful for non-LLM
+**Eager mode** registers all 252 tools directly, which may be useful for non-LLM
 clients or debugging but consumes significant context.
 
 **Update semantics:** Updates use a read-modify-write flow against the
@@ -354,13 +354,13 @@ MCP server.
 3. Test with mcp-cli:
 
    The `.mcp_servers.json` config provides two server entries:
-   - `go-unifi-mcp` - eager mode (242 tools)
+   - `go-unifi-mcp` - eager mode (252 tools)
    - `go-unifi-mcp-lazy` - lazy mode (3 meta-tools)
 
    **Eager mode** (direct tool access):
 
    ```bash
-   # List tools (shows all 242)
+   # List tools (shows all 252)
    mcp-cli info go-unifi-mcp
 
    # Call a tool directly


### PR DESCRIPTION
- Add release notes for the go-unifi v1.11.2 tool expansion
- Update README tool counts from 242 to 252
