### PR TITLE
Manage pinned dependencies with Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
   "rebaseWhen": "behind-base-branch",
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
+  "pre-commit": {
+    "enabled": true
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -38,6 +41,15 @@
         "mkMcpCli\\s*=\\s*pkgs:\\s*let\\s*version\\s*=\\s*\"(?<currentValue>[^\"]+)\";"
       ],
       "depNameTemplate": "philschmid/mcp-cli",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^flake\\.nix$"],
+      "matchStrings": [
+        "mkMcpPublisher\\s*=\\s*pkgs:\\s*let\\s*version\\s*=\\s*\"(?<currentValue>[^\"]+)\";"
+      ],
+      "depNameTemplate": "modelcontextprotocol/registry",
       "datasourceTemplate": "github-releases"
     },
     {


### PR DESCRIPTION
Add a regex manager for the publisher version pinned in flake.nix so Renovate can propose upgrades and exercise the existing cross-platform hash repair workflow.

Enable Renovate’s built-in pre-commit manager so the existing automerge rule can manage hook revisions.