### PR TITLE
Label pre-commit automerge PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -75,7 +75,8 @@
     {
       "description": "Automerge pre-commit hook updates",
       "matchManagers": ["pre-commit"],
-      "automerge": true
+      "automerge": true,
+      "addLabels": ["automerge"]
     },
     {
       "description": "Automerge Go patch and digest updates",


### PR DESCRIPTION
Add the automerge label to Renovate pre-commit updates so they match the repository convention and are easy to identify.
