### PR TITLE
Recover panics in tool handlers instead of crashing the connection

### DIFF
--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -115,6 +115,67 @@ func TestLazyModeEndToEnd(t *testing.T) {
 	client.AssertExpectations(t)
 }
 
+// TestToolHandlerPanicIsRecovered guards against regressions in the
+// underlying go-unifi client (e.g. the go-playground/validator "Bad field
+// type []string" panic triggered by a WLAN update with wlan_bands set,
+// github.com/filipowm/go-unifi issue reproduced 2026-07-02 and fixed
+// upstream in v1.9.0) taking down the whole MCP connection instead of
+// surfacing as a normal tool error. Any panic raised inside a tool handler
+// -- from this bug, a different validator bug, or anything else in the
+// client -- must be converted into a clean JSON-RPC error, and the
+// connection must stay usable for subsequent calls afterward. Before the
+// fix this panics straight out of CallTool and takes the whole test binary
+// down with it, mirroring how the panic took down the real stdio MCP
+// connection.
+func TestToolHandlerPanicIsRecovered(t *testing.T) {
+	ctx := context.Background()
+	client := servermocks.NewClient(t)
+	client.On("ListNetwork", mock.Anything, "default").
+		Panic("reflect: Bad field type []string for field WLANBands").Once()
+	client.On("ListDevice", mock.Anything, "default").Return([]unifi.Device{}, nil).Once()
+
+	s, err := New(Options{Client: client, Mode: ModeEager})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	mcpClient, err := clientpkg.NewInProcessClient(s)
+	require.NoError(t, err)
+	defer func() {
+		err = mcpClient.Close()
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, mcpClient.Start(ctx))
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initRequest.Params.ClientInfo = mcp.Implementation{Name: "integration-test", Version: "1.0.0"}
+	_, err = mcpClient.Initialize(ctx, initRequest)
+	require.NoError(t, err)
+
+	listNetworkRequest := mcp.CallToolRequest{}
+	listNetworkRequest.Params.Name = "list_network"
+	listNetworkRequest.Params.Arguments = map[string]any{}
+
+	// The panicking call must come back as a normal (non-panicking) error,
+	// not crash the test binary / connection.
+	_, err = mcpClient.CallTool(ctx, listNetworkRequest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "panic recovered")
+	assert.Contains(t, err.Error(), "list_network")
+
+	// The connection must still be usable for a subsequent call -- this is
+	// the actual regression the fix guards against.
+	listDeviceRequest := mcp.CallToolRequest{}
+	listDeviceRequest.Params.Name = "list_device"
+	listDeviceRequest.Params.Arguments = map[string]any{}
+	result, err := mcpClient.CallTool(ctx, listDeviceRequest)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.IsError)
+
+	client.AssertExpectations(t)
+}
+
 func TestEagerModeEndToEnd(t *testing.T) {
 	ctx := context.Background()
 	client := servermocks.NewClient(t)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -63,6 +63,12 @@ func New(opts Options) (*server.MCPServer, error) {
 		ServerName,
 		Version,
 		server.WithToolCapabilities(true),
+		// Convert any panic inside a tool handler (e.g. a go-unifi client
+		// method panicking on a malformed request) into a clean tool-call
+		// error instead of taking down the whole stdio connection. Applies
+		// to every registered tool in both lazy and eager mode, since all
+		// tool calls route through the same MCPServer.handleToolCall.
+		server.WithRecovery(),
 	)
 
 	if mode == ModeEager {


### PR DESCRIPTION
A panic raised by the underlying go-unifi client during a tool call propagates straight through `MCPServer.handleToolCall` and kills the whole stdio connection instead of surfacing as a tool-call error.

I hit this concretely via `github.com/filipowm/go-unifi@v1.8.1`'s WLAN struct: the `wlan_bands` field had `validate:"oneof=..."` instead of `validate:"dive,oneof=..."`, so go-playground/validator's `isOneOf` panicked with `reflect: Bad field type []string` on any WLAN update where `wlan_bands` was populated (basically every "both"-band WLAN). That specific bug was already fixed upstream in go-unifi v1.9.0 (this repo is already on v1.11.2, past the fix), but nothing stops the next panic-producing bug in go-unifi — or anywhere else in a handler — from taking the server down the same way.

Fix: register mcp-go's built-in `server.WithRecovery()` `ServerOption` when constructing the `MCPServer`. Every tool call, in both lazy and eager mode, routes through the same `handleToolCall`, which applies `toolHandlerMiddlewares` to the resolved handler before invoking it, so this one option covers all ~250 generated tools plus the meta `execute`/`batch` wrappers, not just the WLAN update path that happened to surface this.

Added `TestToolHandlerPanicIsRecovered`, which mocks a client method to panic and asserts:
1. the panic comes back as a normal error, not a crash
2. the connection stays usable for a subsequent call afterward

Without the fix this test crashes the whole test binary (confirmed by running it against the pre-fix code — full panic trace matches the one from the original bug report, bottoming out in the same `handleToolCall` -> `WrapHandler` -> `GenericList` chain).

`go build ./...`, `go vet ./...`, `go test ./...`, and `golangci-lint run ./...` all pass clean.

No live UniFi config was touched to develop or verify this — the reproduction and fix are both via a mocked client.