### PR TITLE
Recover panics in lazy batch workers

### DIFF
--- a/internal/meta/batch.go
+++ b/internal/meta/batch.go
@@ -3,6 +3,7 @@ package meta
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -12,6 +13,16 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
+
+func callHandlerWithRecovery(ctx context.Context, req mcp.CallToolRequest, handler server.ToolHandlerFunc) (result *mcp.CallToolResult, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("panic recovered in %s tool handler: %v", req.Params.Name, recovered)
+		}
+	}()
+
+	return handler(ctx, req)
+}
 
 // BatchHandler returns a handler that executes multiple tools in parallel.
 func BatchHandler(client unifi.Client, registry map[string]generated.HandlerFunc, resolver *resolve.Resolver) server.ToolHandlerFunc {
@@ -77,7 +88,7 @@ func BatchHandler(client unifi.Client, registry map[string]generated.HandlerFunc
 				if !strings.HasPrefix(toolName, "delete_") {
 					handler = resolve.WrapHandler(handler, resolver)
 				}
-				toolResult, err := handler(ctx, innerReq)
+				toolResult, err := callHandlerWithRecovery(ctx, innerReq, handler)
 				if err != nil {
 					result["error"] = err.Error()
 					mu.Lock()

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -340,6 +340,48 @@ func TestBatch_PartialFailure(t *testing.T) {
 	assert.NotContains(t, results[2], "error")
 }
 
+func TestBatch_PanicReturnsItemError(t *testing.T) {
+	registry := map[string]generated.HandlerFunc{
+		"panic_tool": func(_ unifi.Client) server.ToolHandlerFunc {
+			return func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				panic("test panic")
+			}
+		},
+		"safe_tool": func(_ unifi.Client) server.ToolHandlerFunc {
+			return func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				return mcp.NewToolResultText(`{"result": "ok"}`), nil
+			}
+		},
+	}
+
+	handler := BatchHandler(nil, registry, nil)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"calls": []any{
+			map[string]any{"tool": "panic_tool", "arguments": map[string]any{}},
+			map[string]any{"tool": "safe_tool", "arguments": map[string]any{}},
+		},
+	}
+
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.IsError)
+
+	var results []map[string]any
+	content := result.Content[0].(mcp.TextContent)
+	err = json.Unmarshal([]byte(content.Text), &results)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "panic_tool", results[0]["tool"])
+	assert.Contains(t, results[0]["error"], "panic recovered")
+	assert.Contains(t, results[0]["error"], "test panic")
+	assert.Equal(t, "safe_tool", results[1]["tool"])
+	assert.NotContains(t, results[1], "error")
+	assert.Equal(t, map[string]any{"result": "ok"}, results[1]["result"])
+}
+
 func TestBatch_InvalidCallFormat(t *testing.T) {
 	registry := make(map[string]generated.HandlerFunc)
 	handler := BatchHandler(nil, registry, nil)

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -176,6 +176,74 @@ func TestToolHandlerPanicIsRecovered(t *testing.T) {
 	client.AssertExpectations(t)
 }
 
+func TestLazyBatchPanicIsRecovered(t *testing.T) {
+	ctx := context.Background()
+	client := servermocks.NewClient(t)
+	client.On("ListNetwork", mock.Anything, "default").Panic("test panic").Once()
+	client.On("ListDevice", mock.Anything, "default").Return([]unifi.Device{}, nil).Twice()
+
+	s, err := New(Options{Client: client, Mode: ModeLazy})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	mcpClient, err := clientpkg.NewInProcessClient(s)
+	require.NoError(t, err)
+	defer func() {
+		err = mcpClient.Close()
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, mcpClient.Start(ctx))
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initRequest.Params.ClientInfo = mcp.Implementation{Name: "integration-test", Version: "1.0.0"}
+	_, err = mcpClient.Initialize(ctx, initRequest)
+	require.NoError(t, err)
+
+	batchRequest := mcp.CallToolRequest{}
+	batchRequest.Params.Name = "batch"
+	batchRequest.Params.Arguments = map[string]any{
+		"calls": []any{
+			map[string]any{"tool": "list_network", "arguments": map[string]any{}},
+			map[string]any{"tool": "list_device", "arguments": map[string]any{}},
+		},
+	}
+
+	batchResult, err := mcpClient.CallTool(ctx, batchRequest)
+	require.NoError(t, err)
+	require.NotNil(t, batchResult)
+	assert.False(t, batchResult.IsError)
+
+	var batchResults []map[string]any
+	require.NotEmpty(t, batchResult.Content)
+	batchContent, ok := batchResult.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	err = json.Unmarshal([]byte(batchContent.Text), &batchResults)
+	require.NoError(t, err)
+	require.Len(t, batchResults, 2)
+	assert.Equal(t, "list_network", batchResults[0]["tool"])
+	panicError, ok := batchResults[0]["error"].(string)
+	require.True(t, ok)
+	assert.Contains(t, panicError, "panic recovered")
+	assert.Contains(t, panicError, "test panic")
+	assert.Equal(t, "list_device", batchResults[1]["tool"])
+	assert.NotContains(t, batchResults[1], "error")
+
+	// The lazy-mode session must remain usable after the recovered batch panic.
+	executeRequest := mcp.CallToolRequest{}
+	executeRequest.Params.Name = "execute"
+	executeRequest.Params.Arguments = map[string]any{
+		"tool":      "list_device",
+		"arguments": map[string]any{},
+	}
+	executeResult, err := mcpClient.CallTool(ctx, executeRequest)
+	require.NoError(t, err)
+	require.NotNil(t, executeResult)
+	assert.False(t, executeResult.IsError)
+
+	client.AssertExpectations(t)
+}
+
 func TestEagerModeEndToEnd(t *testing.T) {
 	ctx := context.Background()
 	client := servermocks.NewClient(t)


### PR DESCRIPTION
Lazy batch calls run outside the MCP recovery middleware because each
handler executes in its own goroutine.

- Convert individual handler panics into batch item errors
- Allow other batch items and subsequent MCP calls to continue
- Add unit and lazy-mode integration coverage
