### PR TITLE
Prepare v0.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-07-24
+
+### Fixed
+
+- Fix panic handling so unexpected failures from the underlying go-unifi client
+  or generated handlers return MCP errors instead of terminating the current
+  connection. Direct eager tools and lazy `execute` calls now recover at the MCP
+  handler boundary, while lazy `batch` calls recover inside each parallel
+  worker, report an error only for the failing item, preserve successful sibling
+  results, and allow later requests to continue. For example, a panic such as
+  `reflect: Bad field type []string` now returns a
+  `panic recovered in <tool> tool handler` error instead of taking down the
+  server (#148, #172)
+
+### Changed
+
+- Update the MCP runtime, GitHub Actions, and development validation tooling,
+  and use the default Codex reasoning configuration for Renovate evaluations
+
 ## [0.3.0] - 2026-07-15
 
 ### Added
@@ -75,6 +94,7 @@ and this project adheres to
 - Pre-built binaries for linux and macOS (amd64 and arm64)
 - Configurable site selection and authentication via environment variables
 
+[0.3.1]: https://github.com/claytono/go-unifi-mcp/releases/tag/v0.3.1
 [0.3.0]: https://github.com/claytono/go-unifi-mcp/releases/tag/v0.3.0
 [0.2.0]: https://github.com/claytono/go-unifi-mcp/releases/tag/v0.2.0
 [0.1.1]: https://github.com/claytono/go-unifi-mcp/releases/tag/v0.1.1

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -1,6 +1,6 @@
 // Package meta provides meta-tools for lazy mode operation.
-// In lazy mode, only 3 meta-tools are registered instead of 242 direct tools,
-// reducing context size from ~5000 tokens to ~200 tokens.
+// In lazy mode, only 3 meta-tools are registered instead of 252 direct tools,
+// reducing context size from ~55K tokens to ~200 tokens.
 package meta
 
 import (

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,7 +26,7 @@ type Mode string
 const (
 	// ModeLazy registers only 3 meta-tools (~200 tokens context).
 	ModeLazy Mode = "lazy"
-	// ModeEager registers all 242 direct tools (~55K tokens context).
+	// ModeEager registers all 252 direct tools (~55K tokens context).
 	ModeEager Mode = "eager"
 )
 
@@ -39,7 +39,7 @@ type Options struct {
 
 // New creates a new MCP server with UniFi tools registered.
 // In lazy mode (default), only 3 meta-tools are registered for reduced context.
-// In eager mode, all 242 direct tools are registered.
+// In eager mode, all 252 direct tools are registered.
 func New(opts Options) (*server.MCPServer, error) {
 	if opts.Client == nil {
 		return nil, fmt.Errorf("client is required")


### PR DESCRIPTION
Document the panic recovery fixes and maintenance updates included
since v0.3.0.

- Add v0.3.1 changelog entries and release link
- Correct eager-mode tool count comments
